### PR TITLE
Update maturity level

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 - **Identifier:** <https://stac-extensions.github.io/stats/v0.2.0/schema.json>
 - **Field Name Prefix**: stats
 - **Scope:** Catalog, Collection
-- **Extension [Maturity Classification](https://github.com/radiantearth/stac-spec/tree/master/extensions/README.md#extension-maturity):** Proposal
+- **Extension [Maturity Classification](https://github.com/radiantearth/stac-spec/tree/master/extensions/README.md#extension-maturity):** Pilot
 - **Owner**: @tschaub
 
 This document explains the Stats Extension to the [SpatioTemporal Asset


### PR DESCRIPTION
Update the maturity level to **Pilot** following the STAC maturity classification.

Reason: 1 implementation (Planet / Crawler) and version number is still 0.2.0